### PR TITLE
Fix pregnancy tracker negative date handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -92,8 +92,15 @@ function initTracker() {
     const pdr = new Date(start.getTime() + 280 * 24 * 60 * 60 * 1000);
     pdrElement.textContent = formatDate(pdr);
 
-    const diffTime = Math.abs(today - start);
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    const diffTime = today - start;
+    if (diffTime < 0) {
+      currentWeekElement.textContent = '0 неделя';
+      exactDurationElement.textContent = 'Беременность ещё не началась';
+      updateProgressBar(0);
+      weekTipsElement.innerHTML = '<p>Беременность ещё не началась.</p>';
+      return;
+    }
+    const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
     const weeks = Math.floor(diffDays / 7) + 1;
     const days = diffDays % 7;
 
@@ -145,8 +152,12 @@ function initTracker() {
 
     const date = new Date(customDate);
     const start = getCorrectedStartDate();
-    const diffTime = Math.abs(date - start);
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    const diffTime = date - start;
+    if (diffTime < 0) {
+      alert('Указанная дата раньше начала беременности.');
+      return;
+    }
+    const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
     const weeks = Math.floor(diffDays / 7) + 1;
     const days = diffDays % 7;
 


### PR DESCRIPTION
## Summary
- prevent pregnancy week calculations for dates before the start date
- show message when chosen date predates pregnancy start

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689e2bae9bd4833387f58ba506b094f9