### PR TITLE
Consolidate age calculation and remove exposed API key

### DIFF
--- a/child-tracker.js
+++ b/child-tracker.js
@@ -98,29 +98,6 @@ if (typeof document !== 'undefined') {
     }
 
 
-    function getAgeString(birthDateStr) {
-        const birth = new Date(birthDateStr);
-        const now = new Date();
-        let years = now.getFullYear() - birth.getFullYear();
-        let months = now.getMonth() - birth.getMonth();
-        let days = now.getDate() - birth.getDate();
-        if (days < 0) {
-            months--;
-            days += new Date(now.getFullYear(), now.getMonth(), 0).getDate();
-        }
-        if (months < 0) {
-            years--;
-            months += 12;
-        }
-        const totalDays = Math.floor((now - birth) / (1000 * 60 * 60 * 24));
-        let res = '';
-        if (years > 0) res += years + ' г. ';
-        if (months > 0) res += months + ' мес. ';
-        res += days + ' дн.';
-        res += ` (всего ${totalDays} дней)`;
-        return res;
-    }
-
     function renderHistoryTable(measurements) {
         const tbody = document.querySelector('#historyTable tbody');
         if (!tbody) return;

--- a/script.js
+++ b/script.js
@@ -7,7 +7,8 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 // --- ВСТАВЬТЕ СВОЙ КЛЮЧ OpenRouter НИЖЕ ---
-window.OPENROUTER_API_KEY = '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';
+// Оставьте пустым или используйте безопасный способ загрузки ключа в рантайме.
+window.OPENROUTER_API_KEY = '';
 // ------------------------------------------
 
 // Инициализация трекера беременности


### PR DESCRIPTION
## Summary
- ensure child age calculation uses a single function with future-date protection
- remove hardcoded OpenRouter API key and document how to supply it securely

## Testing
- `node --test tests/child-tracker.test.js`
- `node --check child-tracker.js`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a06600004c8333ad8b935244aa7eb5